### PR TITLE
Fix comment for sketches.js

### DIFF
--- a/export-scripts/export_sketches.py
+++ b/export-scripts/export_sketches.py
@@ -31,7 +31,7 @@ for _, row in df.iterrows():
     with open(os.path.join(sketch_dir, 'index.html'), 'w', encoding='utf-8') as f:
         f.write(html)
 
-    # 4b) sketch.js
+    # 4b) sketches.js
     with open(os.path.join(sketch_dir, 'sketches.js'), 'w', encoding='utf-8') as f:
         f.write(code)
 


### PR DESCRIPTION
## Summary
- fix comment to match file name `sketches.js`

## Testing
- `python -m py_compile export-scripts/export_sketches.py`


------
https://chatgpt.com/codex/tasks/task_e_6841bc46117c8324bf1765b8407e5e87