### PR TITLE
Fix index generation paths

### DIFF
--- a/export/generate_index.py
+++ b/export/generate_index.py
@@ -1,6 +1,9 @@
 import os
 
-EXPORT_DIR = '../export'
+# Determine the export directory relative to this script location
+EXPORT_DIR = os.path.dirname(os.path.abspath(__file__))
+TEMPLATE_FILE = os.path.join(os.path.dirname(EXPORT_DIR), 'export-scripts', 'template-index.html')
+OUTPUT_FILE = os.path.join(EXPORT_DIR, 'index.html')
 sketches = sorted(os.listdir(EXPORT_DIR))
 
 # Criar a lista de <li> com links
@@ -10,14 +13,14 @@ for folder in sketches:
         items.append(f'<li><a href="{folder}/index.html">{folder}</a></li>')
 
 # Lê o modelo
-with open('template-index.html', 'r', encoding='utf-8') as f:
+with open(TEMPLATE_FILE, 'r', encoding='utf-8') as f:
     template = f.read()
 
 # Substitui {{SKETCH_LIST}} pelo HTML gerado
 html = template.replace('{{SKETCH_LIST}}', '\n'.join(items))
 
 # Grava no ficheiro final
-with open(os.path.join(EXPORT_DIR, 'index.html'), 'w', encoding='utf-8') as f:
+with open(OUTPUT_FILE, 'w', encoding='utf-8') as f:
     f.write(html)
 
 print("Ficheiro index.html criado em /export")

--- a/export/index.html
+++ b/export/index.html
@@ -2,7 +2,7 @@
 <html lang="pt">
 <head>
   <meta charset="UTF-8">
-  <title>Building Creative Machines Visual Gallery</title>
+  <title>Galeria de Sketches p5.js</title>
   <style>
     body {
       font-family: sans-serif;
@@ -33,7 +33,7 @@
   </style>
 </head>
 <body>
-  <h1>Building Creative Machines Visual Gallery</h1>
+  <h1>Galeria de Sketches</h1>
   <ul>
     <li><a href="sketch-1974503-the-space-sprint/index.html">sketch-1974503-the-space-sprint</a></li>
 <li><a href="sketch-1975117-breakout/index.html">sketch-1975117-breakout</a></li>
@@ -280,4 +280,3 @@
   </ul>
 </body>
 </html>
-"<!-- trigger GitHub Pages -->" 

--- a/generate_index.py
+++ b/generate_index.py
@@ -1,6 +1,10 @@
 import os
 
-EXPORT_DIR = '../export'
+# Determine the export directory relative to this script location
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+EXPORT_DIR = os.path.join(BASE_DIR, 'export')
+TEMPLATE_FILE = os.path.join(BASE_DIR, 'export-scripts', 'template-index.html')
+OUTPUT_FILE = os.path.join(EXPORT_DIR, 'index.html')
 sketches = sorted(os.listdir(EXPORT_DIR))
 
 # Criar a lista de <li> com links
@@ -10,14 +14,14 @@ for folder in sketches:
         items.append(f'<li><a href="{folder}/index.html">{folder}</a></li>')
 
 # Lê o modelo
-with open('template-index.html', 'r', encoding='utf-8') as f:
+with open(TEMPLATE_FILE, 'r', encoding='utf-8') as f:
     template = f.read()
 
 # Substitui {{SKETCH_LIST}} pelo HTML gerado
 html = template.replace('{{SKETCH_LIST}}', '\n'.join(items))
 
 # Grava no ficheiro final
-with open(os.path.join(EXPORT_DIR, 'index.html'), 'w', encoding='utf-8') as f:
+with open(OUTPUT_FILE, 'w', encoding='utf-8') as f:
     f.write(html)
 
 print("Ficheiro index.html criado em /export")


### PR DESCRIPTION
## Summary
- fix path discovery for export folder in Python scripts
- update generated index.html

## Testing
- `python3 generate_index.py`
- `python3 export/generate_index.py`


------
https://chatgpt.com/codex/tasks/task_e_6841b7042b08832490bfbd45bc04976c