### PR TITLE
Add Enso Sunrise sketch

### DIFF
--- a/index.html
+++ b/index.html
@@ -1275,7 +1275,11 @@
     <div class="card" data-url="sketch-2647001-elegant-squares/index.html">
       <div class="title">2647001 Elegant Squares</div>
     </div>
-    
+
+    <div class="card" data-url="sketch-2647002-enso-sunrise/index.html">
+      <div class="title">2647002 Enso Sunrise</div>
+    </div>
+
   </div>
 
   <script>

--- a/sketch-2647002-enso-sunrise/index.html
+++ b/sketch-2647002-enso-sunrise/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>Enso Sunrise</title>
+  <script src="https://cdn.jsdelivr.net/npm/p5@1.6.0/lib/p5.min.js"></script>
+  <style>
+    body, html { margin: 0; padding: 0; background: #ffffff; }
+    canvas { display: block; }
+  </style>
+</head>
+<body>
+  <script src="sketches.js"></script>
+</body>
+</html>

--- a/sketch-2647002-enso-sunrise/sketches.js
+++ b/sketch-2647002-enso-sunrise/sketches.js
@@ -1,0 +1,33 @@
+let angle = 0;
+let diameter;
+
+function setup() {
+  createCanvas(windowWidth, windowHeight);
+  stroke(220, 20, 60); // deep red
+  noFill();
+  strokeWeight(20);
+  strokeCap(ROUND);
+  diameter = min(width, height) * 0.6;
+}
+
+function draw() {
+  background(255);
+  translate(width / 2, height / 2);
+  let endAngle = map(angle, 0, TWO_PI, 0, TWO_PI);
+  arc(0, 0, diameter, diameter, 0, endAngle);
+  angle += 0.03;
+  if (angle > TWO_PI) {
+    angle = 0;
+  }
+  resetMatrix();
+  fill(0);
+  noStroke();
+  textAlign(CENTER, CENTER);
+  textSize(32);
+  text('日本', width - 50, height - 40); // identifies as Japanese
+}
+
+function windowResized() {
+  resizeCanvas(windowWidth, windowHeight);
+  diameter = min(width, height) * 0.6;
+}


### PR DESCRIPTION
## Summary
- create a Japanese minimalist sketch `Enso Sunrise`
- list it on the index page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842b0ee362c83249424b25fdef3a442